### PR TITLE
Errors handling

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "BibParser"
 uuid = "13533e5b-e1c2-4e57-8cef-cac5e52f6474"
 authors = ["azzaare <jf@baffier.fr>"]
-version = "0.1.11"
+version = "0.1.12"
 
 [deps]
 BibInternal = "2027ae74-3657-4b95-ae00-e2f7d55c3e64"

--- a/examples/error.bib
+++ b/examples/error.bib
@@ -1,0 +1,70 @@
+@string{ var varception = "Test var error"}
+
+@article
+{InvalidEntryKind,
+    author   = "Jean-François Baffier",
+    title    = "Test CJK: バフィエ最高",
+    journal  = "Proceedings of the National Academy of Sciences",
+    year     = 1963,
+    volume   = "50",
+    number   = "6",
+    pages    = "1143--1148",
+}
+
+@art icle{InvalidEntryKind,
+    author   = "Jean-François Baffier",
+    title    = "Test CJK: バフィエ最高",
+    journal  = "Proceedings of the National Academy of Sciences",
+    year     = 1963,
+    volume   = "50",
+    number   = "6",
+    pages    = "1143--1148",
+}
+
+@article{keyer@book{previous_entry_is_incomplete,
+  author         = {test},
+  editor         = {test},
+  title          = {test},
+  publisher      = {test},
+  year           = {123}
+}
+
+@article{Invalid Key,
+    author   = "Jean-François Baffier",
+    title    = "Test CJK: バフィエ最高",
+    journal  = "Proceedings of the National Academy of Sciences",
+    year     = 1963,
+    volume   = "50",
+    number   = "6",
+    pages    = "1143--1148",
+}
+
+@article{InvalidFieldName,
+    author me that is   = "Jean-François Baffier",
+    title    = "Test CJK: バフィエ最高",
+    journal  = "Proceedings of the National Academy of Sciences",
+    year     = 1963,
+    volume   = "50",
+    number   = "6",
+    pages    = "1143--1148",
+}
+
+@article{InvalidFieldVar,
+    author   = me and me,
+    title    = "Test CJK: バフィエ最高",
+    journal  = "Proceedings of the National Academy of Sciences",
+    year     = 1963,
+    volume   = "50",
+    number   = "6",
+    pages    = "1143--1148",
+}
+
+@article{InvalidFieldNumber,
+    author   = ""Jean-François Baffier"",
+    title    = "Test CJK: バフィエ最高",
+    journal  = "Proceedings of the National Academy of Sciences",
+    year     = 1963 1948,
+    volume   = "50",
+    number   = "6",
+    pages    = "1143--1148",
+}

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,7 +1,7 @@
 using BibParser, BibParser.BibTeX
 using Test
 
-for file in ["test.bib"]
+for file in ["test.bib", "error.bib"]
     println("\nstart $file")
     parsed = parse_file("../examples/$file")
 


### PR DESCRIPTION
This PR fix (roughly) the treatment of BibTeX errors.

Errors are printed as warning, and the parser moves to the next entry.