### PR TITLE
Fixing issue #22 by restructuring tracking of curly brace nesting.

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "BibParser"
 uuid = "13533e5b-e1c2-4e57-8cef-cac5e52f6474"
 authors = ["azzaare <jf@baffier.fr>"]
-version = "0.1.17"
+version = "0.1.18"
 
 [deps]
 BibInternal = "2027ae74-3657-4b95-ae00-e2f7d55c3e64"


### PR DESCRIPTION
Fixed the problem of the mutation of strings within the curly braces entries in issue #22.

Note that i did not change the stability of the parser!
Unequal numbers of `{` and `}` after the sequence `<entry> = ` will still lead to misbehaviour of the parser (which is not necessarily bad).

```julia
using Pkg
Pkg.activate(".")
using BibParser

test = parse_entry(raw"
@Article{2015Nguyen,
  author    = {Vinh Phu Nguyen and Cosmin Anitescu and St{\'{e}}phane P.A. Bordas and Timon Rabczuk},
  journal   = {Mathematics and Computers in Simulation},
  title     = {Isogeometric analysis: An overview and computer implementation aspects},
  year      = {2015},
  month     = {nov},
  pages     = {89--116},
  volume    = {117},
  doi       = {10.1016/j.matcom.2015.05.008},
  publisher = {Elsevier {BV}},
}
")
display(test["2015Nguyen"].authors)
```

```julia
4-element Vector{BibInternal.Name}:
 BibInternal.Name("", "Nguyen", "", "Vinh", " Phu")
 BibInternal.Name("", "Anitescu", "", "Cosmin", "")
 BibInternal.Name("", "Bordas", "", "St{\\'{e}}phane", " P.A.")
 BibInternal.Name("", "Rabczuk", "", "Timon", "")
```


