### PR TITLE
Add check keyword to docstring

### DIFF
--- a/src/BibParser.jl
+++ b/src/BibParser.jl
@@ -18,7 +18,7 @@ include("cff.jl")
 using .CFF: CFF
 
 """
-    parse_file(path::String; parser::Symbol = :BibTeX)
+    parse_file(path::String, parser::Symbol = :BibTeX; check=:error)
 Parse a bibliography file. Default to BibTeX format. Other options available: CFF (CSL-JSON coming soon).
 For bibliography formats with formatting rules (such as `:BibTeX`), the `check` keyword argument can be set to `:none` (or `nothing`), `:warn`, or `:error`.
 """
@@ -28,7 +28,7 @@ parse_file(path, ::Val{:CFF}; check) = CFF.parse_file(path)
 parse_file(path, parser=:BibTeX; check=:error) = parse_file(path, Val(parser); check)
 
 """
-    parse_entry(entry::String; parser::Symbol = :BibTeX)
+    parse_entry(entry::String; parser::Symbol = :BibTeX, check = :error)
 Parse a string entry. Default to BibTeX format. No other options available yet (CSL-JSON coming soon).
 
 For bibliography formats with formatting rules (such as `:BibTeX`), the `check` keyword argument can be set to `:none` (or `nothing`), `:warn`, or `:error`.


### PR DESCRIPTION
It's mentioned in the docstring but it's not in the signature. The `parser` is a keyword in the signature but not in the implementation for `parse_file` so I also changed this.