### PR TITLE
Disable testing on pre-releases

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,7 +52,6 @@ jobs:
         version:
           - "lts"
           - "1"
-          - "pre"
         os:
           - ubuntu-latest
         arch:


### PR DESCRIPTION
See https://github.com/Humans-of-Julia/BibInternal.jl/pull/52

Except that here, I don't think we have the same branch protection rules in place. So I'll probably be able to merge this myself.