### PR TITLE
Exclude json files from spell check

### DIFF
--- a/_typos.toml
+++ b/_typos.toml
@@ -3,6 +3,9 @@ extend-ignore-re = [
     "iMatix"
 ]
 
+[files]
+extend-exclude = ["*.bib", "*.json"]
+
 [default.extend-words]
 annote = "annote"
 inbrace = "inbrace"


### PR DESCRIPTION
We don't have control over these files, so we shouldn't spellcheck them